### PR TITLE
Lazy load providers (task #9871)

### DIFF
--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -18,5 +18,6 @@ use MyCLabs\Enum\Enum;
  */
 class EventName extends Enum
 {
+    const QOBO_SOCIAL_PROVIDER_LOAD = 'Qobo/Social.providerRegistry.load';
     const QOBO_SOCIAL_CONNECT_TWITTER = 'Qobo/Social.connectAccount.twitter';
 }

--- a/src/Provider/ProviderRegistry.php
+++ b/src/Provider/ProviderRegistry.php
@@ -15,14 +15,18 @@ use Qobo\Social\Utility\ClassUtility;
 /**
  * Provider Registry singleton class
  *
- * Providers should be loaded using the {@link self::set()} method using lazy loading
- * by hooking into a special event, like so:
+ * Providers should be loaded using the {@link self::set()} method during bootstrapping
+ * using lazy loading by hooking into a special event, like so:
  *
  * ```php
  *  $event = new Event((string)EventName::QOBO_SOCIAL_PROVIDER_LOAD(), function ($event, $registry) {
  *      $registry->set('twitter', 'foo', TestProvider::class);
  *  });
  * ```
+ *
+ * This event will be fired only once during the first call to the provider registry,
+ * so if you need to add providers on the application level (in controllers for example)
+ * you may use the {@link self::set()} method directly.
  */
 class ProviderRegistry
 {

--- a/src/Provider/ProviderRegistry.php
+++ b/src/Provider/ProviderRegistry.php
@@ -284,6 +284,7 @@ class ProviderRegistry
     public function exists(string $network, string $name): bool
     {
         self::reload();
+
         return isset($this->providers[$network][$name]);
     }
 
@@ -295,6 +296,7 @@ class ProviderRegistry
     public function getCollection(): Collection
     {
         self::reload();
+
         return new Collection($this->providers);
     }
 }

--- a/src/Provider/ProviderRegistry.php
+++ b/src/Provider/ProviderRegistry.php
@@ -122,7 +122,7 @@ class ProviderRegistry
      *
      * @return void
      */
-    public function reload(): void
+    protected function reload(): void
     {
         if (!self::$loaded) {
             self::$loaded = true;


### PR DESCRIPTION
Lazy load providers during the first call to the provider registry. Helps with defining providers on application level during bootstrap, when necessary database records might not yet exist.