### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,9 @@
             "php": "7.1"
         }
     },
-    "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-       }
-   ],
     "require": {
         "abraham/twitteroauth": "^1.0",
-        "qobo/cakephp-utils": "^13.0"
+        "qobo/cakephp-utils": "dev-cakephp-v38a"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"
@@ -63,6 +57,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "abraham/twitteroauth": "^1.0",
-        "qobo/cakephp-utils": "dev-cakephp-v38a"
+        "qobo/cakephp-utils": "^13.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/tests/TestCase/Controller/AccountsControllerTest.php
+++ b/tests/TestCase/Controller/AccountsControllerTest.php
@@ -23,9 +23,9 @@ class AccountsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
     ];
 
     /**

--- a/tests/TestCase/Controller/KeywordsControllerTest.php
+++ b/tests/TestCase/Controller/KeywordsControllerTest.php
@@ -16,8 +16,8 @@ class KeywordsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Controller/NetworksControllerTest.php
+++ b/tests/TestCase/Controller/NetworksControllerTest.php
@@ -16,8 +16,8 @@ class NetworksControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Accounts',
     ];
 
     /**

--- a/tests/TestCase/Controller/PostsControllerTest.php
+++ b/tests/TestCase/Controller/PostsControllerTest.php
@@ -17,12 +17,12 @@ class PostsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.interaction_types',
-        'plugin.qobo/social.post_interactions',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.posts_topics',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.InteractionTypes',
+        'plugin.Qobo/Social.PostInteractions',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.PostsTopics',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Controller/TopicsControllerTest.php
+++ b/tests/TestCase/Controller/TopicsControllerTest.php
@@ -16,10 +16,10 @@ class TopicsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.topics',
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.posts_topics',
+        'plugin.Qobo/Social.Topics',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.PostsTopics',
     ];
 
     /**

--- a/tests/TestCase/Event/Twitter/ConnectTwitterAccountListenerTest.php
+++ b/tests/TestCase/Event/Twitter/ConnectTwitterAccountListenerTest.php
@@ -51,8 +51,8 @@ class ConnectTwitterAccountListenerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Accounts',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/AccountsTableTest.php
+++ b/tests/TestCase/Model/Table/AccountsTableTest.php
@@ -26,9 +26,9 @@ class AccountsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/InteractionTypesTableTest.php
+++ b/tests/TestCase/Model/Table/InteractionTypesTableTest.php
@@ -26,8 +26,8 @@ class InteractionTypesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.interaction_types',
-        'plugin.qobo/social.networks',
+        'plugin.Qobo/Social.InteractionTypes',
+        'plugin.Qobo/Social.Networks',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/KeywordsTableTest.php
+++ b/tests/TestCase/Model/Table/KeywordsTableTest.php
@@ -26,8 +26,8 @@ class KeywordsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/NetworksTableTest.php
+++ b/tests/TestCase/Model/Table/NetworksTableTest.php
@@ -30,8 +30,8 @@ class NetworksTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Accounts',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/PostInteractionsTableTest.php
+++ b/tests/TestCase/Model/Table/PostInteractionsTableTest.php
@@ -27,9 +27,9 @@ class PostInteractionsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.post_interactions',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.interaction_types',
+        'plugin.Qobo/Social.PostInteractions',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.InteractionTypes',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/PostsTableTest.php
+++ b/tests/TestCase/Model/Table/PostsTableTest.php
@@ -42,10 +42,10 @@ class PostsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/PostsTopicsTableTest.php
+++ b/tests/TestCase/Model/Table/PostsTopicsTableTest.php
@@ -26,9 +26,9 @@ class PostsTopicsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.posts_topics',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.PostsTopics',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/TopicsTableTest.php
+++ b/tests/TestCase/Model/Table/TopicsTableTest.php
@@ -26,9 +26,9 @@ class TopicsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.topics',
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.posts',
+        'plugin.Qobo/Social.Topics',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Posts',
     ];
 
     /**

--- a/tests/TestCase/Provider/ProviderRegistryTest.php
+++ b/tests/TestCase/Provider/ProviderRegistryTest.php
@@ -47,9 +47,9 @@ class ProviderRegistryTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
     ];
 
     /**

--- a/tests/TestCase/Provider/Twitter/TwitterPremiumSearchProviderTest.php
+++ b/tests/TestCase/Provider/Twitter/TwitterPremiumSearchProviderTest.php
@@ -54,14 +54,14 @@ class TwitterPremiumSearchProviderTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.interaction_types',
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.post_interactions',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.posts_topics',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.InteractionTypes',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.PostInteractions',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.PostsTopics',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Provider/Twitter/TwitterUserTimelineProviderTest.php
+++ b/tests/TestCase/Provider/Twitter/TwitterUserTimelineProviderTest.php
@@ -46,14 +46,14 @@ class TwitterUserTimelineProviderTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.interaction_types',
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.post_interactions',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.posts_topics',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.InteractionTypes',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.PostInteractions',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.PostsTopics',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Publisher/AbstractPublisherTest.php
+++ b/tests/TestCase/Publisher/AbstractPublisherTest.php
@@ -44,10 +44,10 @@ class AbstractPublisherTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Publisher/Twitter/TwitterPublisherTest.php
+++ b/tests/TestCase/Publisher/Twitter/TwitterPublisherTest.php
@@ -42,10 +42,10 @@ class TwitterPublisherTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -50,12 +50,12 @@ class ImportTaskTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.accounts',
-        'plugin.qobo/social.keywords',
-        'plugin.qobo/social.networks',
-        'plugin.qobo/social.posts',
-        'plugin.qobo/social.posts_topics',
-        'plugin.qobo/social.topics',
+        'plugin.Qobo/Social.Accounts',
+        'plugin.Qobo/Social.Keywords',
+        'plugin.Qobo/Social.Networks',
+        'plugin.Qobo/Social.Posts',
+        'plugin.Qobo/Social.PostsTopics',
+        'plugin.Qobo/Social.Topics',
     ];
 
     /**

--- a/tests/TestCase/View/Helper/PostInteractionsHelperTest.php
+++ b/tests/TestCase/View/Helper/PostInteractionsHelperTest.php
@@ -18,9 +18,9 @@ class PostInteractionsHelperTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/social.interaction_types',
-        'plugin.qobo/social.post_interactions',
-        'plugin.qobo/social.posts',
+        'plugin.Qobo/Social.InteractionTypes',
+        'plugin.Qobo/Social.PostInteractions',
+        'plugin.Qobo/Social.Posts',
     ];
 
     /**


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

